### PR TITLE
logging query params if passed

### DIFF
--- a/src/biocommons/seqrepo/dataproxy.py
+++ b/src/biocommons/seqrepo/dataproxy.py
@@ -150,8 +150,8 @@ class SeqRepoRESTDataProxy(_SeqRepoDataProxyBase):
 
     def _get_sequence(self, identifier, start=None, end=None):
         url = self.base_url + f"sequence/{identifier}"
-        _logger.info("Fetching %s", url)
         params = {"start": start, "end": end}
+        _logger.info(f"Fetching {url} {params if (start or end) else ''}")
         resp = requests.get(url, params=params)
         if resp.status_code == 404:
             raise KeyError(identifier)


### PR DESCRIPTION
sample output from `pytest` run:

```
Fetching http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.v_QTc1p-MUYdgrRv4LMT6ByXIOsdw3C_ 
Fetching http://localhost:5000/seqrepo/1/sequence/ga4gh:SQ.v_QTc1p-MUYdgrRv4LMT6ByXIOsdw3C_ {'start': 0, 'end': 50}
```